### PR TITLE
Add options for custom theming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+/.vscode

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ https://www.npmjs.com/package/@codbear/reactable
 ![GitHub package.json version](https://img.shields.io/github/package-json/v/codbear/reactable?style=for-the-badge)
 ![GitHub](https://img.shields.io/github/license/codbear/reactable?color=97c423&style=for-the-badge)
 
+## Requirements
++ react 17.0.2 (This library use hooks under the hood)
++ styled-components 5.3.3,
+
 ## Installation
 
 ```bash
@@ -161,15 +165,28 @@ const SuperHerosTable = () => {
 
 [See demo in StoryBook](https://codbear.github.io/reactable/?path=/story/table--with-search-bar)
 
-### Custom table
+### Custom theming
 
-If the default style of the Table component don't fit your needs, or if you want more control over your table, you can use the `useTable` hook.
+You can provide a theme to the Table component if you want to override default theme. For now only the palette can be overrided.
 ```jsx
-import { useTable } from '@codbear/reactable';
+<Table 
+  theme={{
+    palette: {
+      primary: '#ffffff', // The color applied to header background
+      secondary: '#c7c7c7', // The color applied to row background on hover
+      divider: '#000000', // The color applied to borders
+      text: '#000000', // The color applied to text content
+    }
+  }}
+/>
 ```
 
-You have to specify data and columns, itemsPerPage (0 if you don't want pagination).
-You can also specify custom `sortRows` and `filterRows` services.
+The `color` and `headerTextColor` props are now deprecated and should not be used anymore.
+
+You can completely disable theming (palette only) with `isThemeDisabled`.
+```jsx
+<Table isThemeDisabled />
+```
 
 [See how it's implemented in Table component](https://github.com/codbear/reactable/blob/main/src/lib/components/Table/Table.jsx)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@codbear/reactable",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "author": "codbear (https://github.com/codbear)",
   "description": "Create data tables with React",
   "keywords": [

--- a/src/lib/components/Table/Table.jsx
+++ b/src/lib/components/Table/Table.jsx
@@ -26,15 +26,33 @@ const propTypes = {
   itemsPerPage: PropTypes.number,
   itemsPerPageOptions: PropTypes.arrayOf(PropTypes.number),
   hasSearchBar: PropTypes.bool,
+  theme: PropTypes.shape({
+    palette: PropTypes.shape({
+      primary: PropTypes.string,
+      secondary: PropTypes.string,
+      divider: PropTypes.string,
+      text: PropTypes.string,
+    })
+  }),
+  isThemeDisabled: PropTypes.boolean,
 };
 
 const defaultProps = {
   variant: 'outlined',
-  color: '#c7c7c7',
-  headerTextColor: '#000000',
+  color: '',
+  headerTextColor: '',
   itemsPerPage: 0,
   itemsPerPageOptions: [25, 50, 100],
   hasSearchBar: false,
+  theme: {
+    palette: {
+      primary: '#c7c7c7',
+      secondary: '#fafafa',
+      divider: '#e5e8ec',
+      text: '#000000',
+    }
+  },
+  isThemeDisabled: false,
 };
 
 const TableWrapper = styled.div`
@@ -69,6 +87,15 @@ const variantToTableHeaderRow = {
   filled: TableHeaderRowFilled,
 };
 
+const disabledTheme = {
+  palette: {
+    primary: '',
+    secondary: '',
+    divider: '',
+    text: '',
+  }
+}
+
 const Table = ({
   data,
   columns: userDefinedColumns,
@@ -79,17 +106,19 @@ const Table = ({
   itemsPerPageOptions,
   onChangeItemsPerPage,
   hasSearchBar,
+  theme,
+  isThemeDisabled
 }) => {
-  const theme = useMemo(
-    () => ({
+  const memoizedTheme = useMemo(
+    () => isThemeDisabled ? disabledTheme : {
       palette: {
-        primary: color,
-        secondary: '#fafafa',
-        divider: '#e5e8ec',
-        text: headerTextColor,
+        primary: color || theme.palette.primary,
+        secondary: theme.palette.secondary,
+        divider: theme.palette.divider,
+        text: headerTextColor || theme.palette.text,
       },
-    }),
-    [color, headerTextColor]
+    },
+    [color, headerTextColor, isThemeDisabled, theme.palette.divider, theme.palette.primary, theme.palette.secondary, theme.palette.text]
   );
 
   const { columns, rows, hasHeader, onSort, pagination, onSearch } = useTable({
@@ -101,7 +130,7 @@ const Table = ({
   const TableHeaderRow = variantToTableHeaderRow[variant];
 
   return (
-    <ThemeProvider theme={theme}>
+    <ThemeProvider theme={memoizedTheme}>
       <TableContext.Provider
         value={{ onSort, pagination, onChangeItemsPerPage, itemsPerPageOptions, onSearch }}
       >

--- a/src/lib/components/Table/Table.jsx
+++ b/src/lib/components/Table/Table.jsx
@@ -32,7 +32,7 @@ const propTypes = {
       secondary: PropTypes.string,
       divider: PropTypes.string,
       text: PropTypes.string,
-    })
+    }),
   }),
   isThemeDisabled: PropTypes.boolean,
 };
@@ -50,7 +50,7 @@ const defaultProps = {
       secondary: '#fafafa',
       divider: '#e5e8ec',
       text: '#000000',
-    }
+    },
   },
   isThemeDisabled: false,
 };
@@ -93,8 +93,8 @@ const disabledTheme = {
     secondary: '',
     divider: '',
     text: '',
-  }
-}
+  },
+};
 
 const Table = ({
   data,
@@ -107,18 +107,29 @@ const Table = ({
   onChangeItemsPerPage,
   hasSearchBar,
   theme,
-  isThemeDisabled
+  isThemeDisabled,
 }) => {
   const memoizedTheme = useMemo(
-    () => isThemeDisabled ? disabledTheme : {
-      palette: {
-        primary: color || theme.palette.primary,
-        secondary: theme.palette.secondary,
-        divider: theme.palette.divider,
-        text: headerTextColor || theme.palette.text,
-      },
-    },
-    [color, headerTextColor, isThemeDisabled, theme.palette.divider, theme.palette.primary, theme.palette.secondary, theme.palette.text]
+    () =>
+      isThemeDisabled
+        ? disabledTheme
+        : {
+            palette: {
+              primary: color || theme.palette.primary,
+              secondary: theme.palette.secondary,
+              divider: theme.palette.divider,
+              text: headerTextColor || theme.palette.text,
+            },
+          },
+    [
+      color,
+      headerTextColor,
+      isThemeDisabled,
+      theme.palette.divider,
+      theme.palette.primary,
+      theme.palette.secondary,
+      theme.palette.text,
+    ]
   );
 
   const { columns, rows, hasHeader, onSort, pagination, onSearch } = useTable({


### PR DESCRIPTION
You can provide a theme to the Table component if you want to override default theme. For now only the palette can be overrided.
```jsx
<Table 
  theme={{
    palette: {
      primary: '#ffffff', // The color applied to header background
      secondary: '#c7c7c7', // The color applied to row background on hover
      divider: '#000000', // The color applied to borders
      text: '#000000', // The color applied to text content
    }
  }}
/>
```

The `color` and `headerTextColor` props are now deprecated and should not be used anymore.

You can completely disable theming (palette only) with `isThemeDisabled`.
```jsx
<Table isThemeDisabled />
```